### PR TITLE
fall back to superclass get_available_name

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -81,9 +81,6 @@ class SwiftStorage(Storage):
         s = name.strip().replace(' ', '_')
         return re.sub(r'(?u)[^-_\w./]', '', s)
 
-    def get_available_name(self, name):
-        return name
-
     def size(self, name):
         headers, content = self.connection.get_object(self.container_name,
                                                       name)


### PR DESCRIPTION
Delete the provided get_available_name - it did no checking whatsoever.

This now falls back to the superclass method, which uses os.path, so it may still be broken on Windows - although it will now at least work on *nixes.
