### PR TITLE
add configuration which makes created containers public

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -32,6 +32,7 @@ class SwiftStorage(Storage):
     tenant_name = setting('SWIFT_TENANT_NAME')
     container_name = setting('SWIFT_CONTAINER_NAME')
     auto_create_container = setting('SWIFT_AUTO_CREATE_CONTAINER', False)
+    auto_create_container_public = setting('SWIFT_AUTO_CREATE_CONTAINER_PUBLIC', False)
     auto_base_url = setting('SWIFT_AUTO_BASE_URL', True)
     override_base_url = setting('SWIFT_BASE_URL')
     use_temp_urls = setting('SWIFT_USE_TEMP_URLS', False)
@@ -58,10 +59,13 @@ class SwiftStorage(Storage):
                                        self.container_name,
                                        http_conn=self.http_conn)
         except swiftclient.ClientException:
+            headers = {}
             if self.auto_create_container:
+                if self.auto_create_container_public:
+                    headers['X-Container-Read'] = '.r:*'
                 swiftclient.put_container(self.storage_url, self.token,
                                           self.container_name,
-                                          http_conn=self.http_conn)
+                                          http_conn=self.http_conn, headers=headers)
             else:
                 raise ImproperlyConfigured(
                     "Container %s does not exist." % self.container_name)


### PR DESCRIPTION
Added a configuration option (which is by default to false, to not change current behaviour) SWIFT_AUTO_CREATE_CONTAINER_PUBLIC, it will make any created container publicly available.
