### PR TITLE
add name prefix setting

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -221,4 +221,5 @@ class SwiftStorage(Storage):
 class StaticSwiftStorage(SwiftStorage):
     container_name = setting('SWIFT_STATIC_CONTAINER_NAME')
     name_prefix = setting('SWIFT_STATIC_NAME_PREFIX')
+    override_base_url = setting('SWIFT_STATIC_BASE_URL')
 


### PR DESCRIPTION
I've added a setting named SWIFT_{,STATIC_}NAME_PREFIX, it's a prefix prepended to all file names uploaded to swift.

It's used by us to upload static files to per release directory, so SWIFT_STATIC_NAME_PREFIX is set to release number, so we can keep all releases static files in one swift container.
