### PR TITLE
Converted to python 3 and added tenant_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ django-storage-swift recognises the following options.
 | ```SWIFT_KEY``` | None | The key (password) to use to authenticate. |
 | ```SWIFT_AUTH_VERSION``` | 1 | The version of the authentication protocol to use. |
 | ```SWIFT_TENANT_NAME``` | None | The tenant name to use when authenticating. |
+| ```SWIFT_TENANT_ID``` | None | The tenant id to use when authenticating. |
 | ```SWIFT_CONTAINER_NAME``` | None | The container in which to store the files. |
 | ```SWIFT_STATIC_CONTAINER_NAME``` | None | Alternate container used by StaticSwiftStorage. |
 | ```SWIFT_AUTO_CREATE_CONTAINER``` | False | Should the container be created if it does not exist? |

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -42,6 +42,7 @@ class SwiftStorage(Storage):
     temp_url_duration = setting('SWIFT_TEMP_URL_DURATION', 30*60)
     auth_token_duration = setting('SWIFT_AUTH_TOKEN_DURATION', 60*60*23)
     os_extra_options = setting('SWIFT_EXTRA_OPTIONS', {})
+    auto_overwrite = setting('SWIFT_AUTO_OVERWRITE', False)
     _token_creation_time = 0
     _token = ''
     name_prefix = setting('SWIFT_NAME_PREFIX')
@@ -182,17 +183,9 @@ class SwiftStorage(Storage):
         Returns a filename that's free on the target storage system, and
         available for new content to be written to.
         """
-        dir_name, file_name = os.path.split(name)
-        file_root, file_ext = os.path.splitext(file_name)
-        # If the filename already exists, add an underscore and a number
-        # (before the file extension, if one exists) to the filename until the
-        # generated filename doesn't exist.
-        count = itertools.count(1)
-        while self.exists(name):
-            # file_ext includes the dot.
-            name = posixpath.join(dir_name, "%s_%s%s" % (file_root,
-                                                         next(count),
-                                                         file_ext))
+        
+        if not self.auto_overwrite:
+            name = super(SwiftStorage, self).get_available_name(name)
 
         return name
 

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -30,6 +30,7 @@ class SwiftStorage(Storage):
     api_key = setting('SWIFT_KEY')
     auth_version = setting('SWIFT_AUTH_VERSION', 1)
     tenant_name = setting('SWIFT_TENANT_NAME')
+    tenant_id = setting('SWIFT_TENANT_ID')
     container_name = setting('SWIFT_CONTAINER_NAME')
     auto_create_container = setting('SWIFT_AUTO_CREATE_CONTAINER', False)
     auto_create_container_public = setting(
@@ -55,7 +56,7 @@ class SwiftStorage(Storage):
             self.api_username,
             self.api_key,
             auth_version=self.auth_version,
-            os_options=dict(list({"tenant_name": self.tenant_name}.items()) +
+            os_options=dict(list({"tenant_id": self.tenant_id, "tenant_name": self.tenant_name}.items()) +
                             list(self.os_extra_options.items())),
         )
         self.http_conn = swiftclient.http_connection(self.storage_url)


### PR DESCRIPTION
I converted the storage module to python 3 and added the tenant_id to the configuration (including the README.md). The latter fix I found via a user called James Wettenhal who posted it here: https://groups.google.com/forum/#!topic/tardis-devel/wBAyHyz6HuU