### PR TITLE
OpenStack requires that the path is properly encoded.

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -15,7 +15,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.core.files.storage import Storage
 from six import b
-from six.moves.urllib import quote, parse as urlparse
+from six.moves.urllib import parse as urlparse
 
 try:
     import swiftclient
@@ -247,7 +247,7 @@ class SwiftStorage(Storage):
     def _path(self, name):
         if self.name_prefix:
             name = self.name_prefix + name
-        url = urlparse.urljoin(self.base_url, quote(name))
+        url = urlparse.urljoin(self.base_url, urlparse.quote(name))
 
         # Are we building a temporary url?
         if self.use_temp_urls:

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -15,7 +15,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.core.files.storage import Storage
 from six import b
-from six.moves.urllib import parse as urlparse
+from six.moves.urllib import quote, parse as urlparse
 
 try:
     import swiftclient
@@ -247,7 +247,7 @@ class SwiftStorage(Storage):
     def _path(self, name):
         if self.name_prefix:
             name = self.name_prefix + name
-        url = urlparse.urljoin(self.base_url, name)
+        url = urlparse.urljoin(self.base_url, quote(name))
 
         # Are we building a temporary url?
         if self.use_temp_urls:


### PR DESCRIPTION
See http://docs.openstack.org/developer/swift/api/temporary_url_middleware.html#hmac-sha1-signature-for-temporary-urls.

Currently urls for files with non-ascii characters fail with 401 on temp urls, which is fixed by quoting the path.