### PR TITLE
Fix storage.get_available_name 'max_length' argument (Django 1.10)

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -312,7 +312,7 @@ class StaticSwiftStorage(SwiftStorage):
     name_prefix = setting('SWIFT_STATIC_NAME_PREFIX')
     override_base_url = setting('SWIFT_STATIC_BASE_URL')
 
-    def get_available_name(self, name):
+    def get_available_name(self, name, max_length=None):
         """
         When running collectstatic we don't want to return an available name,
         we want to return the same name because if the file exists we want to

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -223,14 +223,15 @@ class SwiftStorage(Storage):
         s = name.strip().replace(' ', '_')
         return re.sub(r'(?u)[^-_\w./]', '', s)
 
-    def get_available_name(self, name):
+    def get_available_name(self, name, max_length=None):
         """
         Returns a filename that's free on the target storage system, and
         available for new content to be written to.
         """
 
         if not self.auto_overwrite:
-            name = super(SwiftStorage, self).get_available_name(name)
+            name = super(SwiftStorage, self).get_available_name(
+                name, max_length)
 
         return name
 


### PR DESCRIPTION
Just forward `max_length` argument to `Storage`.
This change is for Django 1.10.