### PR TITLE
Simple auth feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,12 @@ django-storage-swift recognises the following options.
 +----------------------------------------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``SWIFT_CONTENT_TYPE_FROM_FD``               | False     | Determine the files mimetypes from the actual content rather than from their filename (default).                                                   |
 +----------------------------------------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``SWIFT_SIMPLE_AUTH``                        | False     | Use the provided STORAGE URL and TOKEN rather than querying 2.0 auth for tokens periodically.                                                      |
++----------------------------------------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``SWIFT_OS_STORAGE_URL``                     | None      | Specify the OpenStack storage URL, used with SWIFT_SIMPLE_AUTH                                                                                     |
++----------------------------------------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``SWIFT_OS_TOKEN``                           | None      | Specify the OpenStack authentication token, used with SWIFT_SIMPLE_AUTH                                                                            |
++----------------------------------------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 
 SWIFT\_BASE\_URL
 ~~~~~~~~~~~~~~~~
@@ -133,6 +139,17 @@ You can verify that swift is indeed being used by running, inside
     default_storage.connection
 
 The result should be ``<<swiftclient.client.Connection object ...>>``
+
+OpenStack Simple Auth
+---------------------
+
+To authenticate with a swift installation using the method of a storage URL and generated token, please see the following:
+
+.. code:: python
+
+    SWIFT_SIMPLE_AUTH = True
+    SWIFT_OS_STORAGE_URL = 'https://storage-server:port/v1/AUTH_key'
+    SWIFT_OS_TOKEN = 'swiftgeneratedtoken'
 
 Openstack Keystone/Identity v3
 ------------------------------

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -145,6 +145,8 @@ class SwiftStorage(Storage):
             self.base_url = self.override_base_url
 
     def get_token(self):
+        if self.use_simple_auth:
+            return self._token
         if time() - self._token_creation_time >= self.auth_token_duration:
             new_token = swiftclient.get_auth(
                 self.api_auth_url,

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -57,6 +57,10 @@ class SwiftStorage(Storage):
     _token = ''
     name_prefix = setting('SWIFT_NAME_PREFIX', "")
 
+    use_simple_auth = setting('SWIFT_SIMPLE_AUTH',False)
+    os_storage_url = setting('SWIFT_OS_STORAGE_URL',None)
+    os_token = setting('SWIFT_OS_TOKEN',None)
+
     def __init__(self, **settings):
         # check if some of the settings provided as class attributes
         # should be overwritten

--- a/swift/storage.py
+++ b/swift/storage.py
@@ -82,12 +82,22 @@ class SwiftStorage(Storage):
         os_options.update(self.os_extra_options)
 
         # Get authentication token
-        self.storage_url, self.token = swiftclient.get_auth(
-            self.api_auth_url,
-            self.api_username,
-            self.api_key,
-            auth_version=self.auth_version,
-            os_options=os_options)
+        if self.use_simple_auth:
+            if self.os_storage_url != None:
+                self.storage_url = self.os_storage_url
+            else:
+                raise ImproperlyConfigured("Simple auth missing os_storage_url")
+            if self.os_token != None:
+                self.token = self.os_token
+            else:
+                raise ImproperlyConfigured("Simple auth missing os_token")
+        else:
+            self.storage_url, self.token = swiftclient.get_auth(
+                self.api_auth_url,
+                self.api_username,
+                self.api_key,
+                auth_version=self.auth_version,
+                os_options=os_options)
         self.http_conn = swiftclient.http_connection(self.storage_url)
 
         # Check container


### PR DESCRIPTION
Allows one to use django-storage-swift with just a storage URL and generated token.