### PR TITLE
Wrong override_base_url in static_storage

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -341,7 +341,7 @@ class SwiftStorage(Storage):
 class StaticSwiftStorage(SwiftStorage):
     container_name = setting('SWIFT_STATIC_CONTAINER_NAME', '')
     name_prefix = setting('SWIFT_STATIC_NAME_PREFIX', '')
-    override_base_url = setting('SWIFT_STATIC_BASE_URL', '')
+    override_base_url = setting('SWIFT_STATIC_BASE_URL', None)
 
     def get_available_name(self, name, max_length=None):
         """


### PR DESCRIPTION
Default was '' for override_base_url instead of None. This causes the override to always happen even if no override whas specified. The user would end up getting relative paths instead of full uris to the backend.

This breaks static storage in the .12 release. Media storage works fine.