### PR TITLE
Slightly more complex configuration validation

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,6 +12,7 @@ DATABASES = {
 
 SWIFT_AUTH_URL = 'https://objects.example.com'
 SWIFT_USERNAME = 'user'
-SWIFT_KEY = 'password'
+SWIFT_PASSWORD = 'password'
 SWIFT_TENANT_ID = '11223344556677889900aabbccddeeff'
 SWIFT_CONTAINER_NAME = 'www-media'
+SWIFT_STATIC_CONTAINER_NAME = 'www-static'

--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,5 @@ deps = isort==4.2.5
 
 [flake8]
 show-source = True
-max-line-length = 80
+max-line-length = 100
 exclude = .env, .tox, tests


### PR DESCRIPTION
Validates the configuration from within the initializer so we can have a fair chance of actually writing tests. This also means that validation happens if a user overrides settings through the initializer.

I also added auth version detection based on what parameters are present. A few alternative configuration attributes were also added such as `SWIFT_PASSWORD`, `SWIFT_PROJECT_NAME` and `SWIFT_PROJECT_ID` that fits better when using non-legacy auth.


