### PR TITLE
Enforce auth_version as string

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -31,7 +31,6 @@ def validate_settings(backend):
     if not backend.api_auth_url:
         raise ImproperlyConfigured("The SWIFT_AUTH_URL setting is required")
 
-    # Mandatory auth params
     if not backend.api_username:
         raise ImproperlyConfigured("The SWIFT_USERNAME setting is required")
 
@@ -56,6 +55,9 @@ def validate_settings(backend):
             else:
                 # Set version 1 if no tenant is not defined
                 backend.auth_version = '1'
+
+    # Enforce auth_version into a string (more future proof)
+    backend.auth_version = str(backend.auth_version)
 
     # Validate v2 auth parameters
     if backend.auth_version == '2':

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,13 +8,13 @@ from swift import storage
 
 class SwiftStorageTestCase(TestCase):
 
-    def default_storage(self, auth_version, exclude=None, **params):
+    def default_storage(self, auth_config, exclude=None, **params):
         """Instantiate default storage with auth parameters"""
-        return storage.SwiftStorage(**auth_params(auth_version, exclude=exclude, **params))
+        return storage.SwiftStorage(**auth_params(auth_config, exclude=exclude, **params))
 
-    def static_storage(self, auth_version, exclude=None, **params):
+    def static_storage(self, auth_config, exclude=None, **params):
         """Instantiate static storage with auth parameters"""
-        return storage.StaticSwiftStorage(**auth_params(auth_version, exclude=exclude, **params))
+        return storage.StaticSwiftStorage(**auth_params(auth_config, exclude=exclude, **params))
 
 
 @patch('swift.storage.swiftclient', new=FakeSwift)
@@ -62,6 +62,11 @@ class AuthTest(SwiftStorageTestCase):
         """Missing project_domain in v3 auth"""
         with self.assertRaises(ImproperlyConfigured):
             self.default_storage('v3', exclude=['project_domain_name', 'project_domain_id'])
+
+    def test_auth_v3_int_auth_version(self):
+        """Auth version converts into a string"""
+        backend = self.default_storage('v3', auth_version=3)
+        self.assertEqual(backend.auth_version, '3')
 
 
 @patch('swift.storage.swiftclient', new=FakeSwift)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ AUTH_PARAMETERS = {
         'tenant_id': 'tenant',
         'auth_version': '2',
         'container_name': "container"
-},
+    },
     'v3': {
         'api_auth_url': 'https://objects.example.com',
         'api_username': 'user',
@@ -37,13 +37,13 @@ AUTH_PARAMETERS = {
 }
 
 
-def auth_params(version, exclude=None, **kwargs):
+def auth_params(auth_config, exclude=None, **kwargs):
     """Appends auth parameters"""
-    params = deepcopy(AUTH_PARAMETERS[version])
-    params.update(kwargs)
+    params = deepcopy(AUTH_PARAMETERS[auth_config])
     if exclude:
         for name in exclude:
             del params[name]
+    params.update(kwargs)
     return params
 
 
@@ -95,7 +95,6 @@ class FakeSwift(object):
 
     @classmethod
     def head_container(cls, url, token, container, **kwargs):
-        print("container", container)
         if container not in FakeSwift.containers:
             raise ClientException
 


### PR DESCRIPTION
This should ensure backwards compatibility. This was changed in an earlier PR so this is a fix.

In general version numbers should be strings instead of numbers because you could end up having to represent a version number as a decimal. Example: 3.1 that could end up resolving into 3.09999999 in some cases.

Right now auth version is 1, 2 of 3 but that might not always be the case.
