### PR TITLE
Use an identity decorator if django.utils.deconstruct cannot be imported

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -12,9 +12,14 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files import File
 from django.core.files.storage import Storage
-from django.utils.deconstruct import deconstructible
 from six import b
 from six.moves.urllib import parse as urlparse
+
+try:
+    from django.utils.deconstruct import deconstructible
+except ImportError:
+    def deconstructible(arg):
+        return arg
 
 try:
     import swiftclient


### PR DESCRIPTION
This import line was added by the following commit: https://github.com/blacktorn/django-storage-swift/commit/d4a6e9ea30d64ae4b4e3b4bd179bef05413cafbb

On older versions of django that do not provide django.utils.deconstruct, we get an ImportError. The proposed solution is to use an identity decorator if the current django version does not provide django.utils.deconstruct.