### PR TITLE
Ensure temp_url_key setting is the correct type for use as HMAC key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-storage-swift',
-    version='1.2.14',
+    version='1.2.15',
     description='OpenStack Swift storage backend for Django',
     long_description=open('README.rst').read(),
     url='http://github.com/blacktorn/django-storage-swift',


### PR DESCRIPTION
This change assists with the generation of temporary URLs for private SWIFT content, by ensuring that the `SWIFT_TEMP_URL_KEY` is converted to a (non-unicode) string.

If `SWIFT_TEMP_URL_KEY` is a unicode string, which happens if django app settings are parsed from JSON, then an [error like this one](http://stackoverflow.com/questions/20849805/python-hmac-typeerror-character-mapping-must-return-integer-none-or-unicode) is thrown during temporary URL creation: `HMAC TypeError: character mapping must return integer, None or unicode`

**Manual Testing instructions**:

Setup:
1. Create a file called 'env.json', which contains your SWIFT credentials and container name, e.g.,

    ```
    {
      "SWIFT_AUTH_URL": "https://auth.cloud.ovh.net/v2.0",
      "SWIFT_USERNAME": "xxx",
      "SWIFT_PASSWORD": "xxx",
      "SWIFT_TENANT_NAME": "xxx",
      "SWIFT_CONTAINER_NAME": "xxx",
      "SWIFT_USE_TEMP_URLS": true,
      "SWIFT_TEMP_URL_KEY": "xxx",
      "SWIFT_FILE_TO_SHARE": "file.txt"
    }
    ```

1. In the same location as `env.json`, create this `web.py` script to run a [minimal Django app](http://softwaremaniacs.org/blog/2011/01/07/django-micro-framework/en/):

  ```python
    #### Setup
 
    from django.conf import settings
    import json
 
    with open("env.json") as env_file:
        ENV_TOKENS = json.load(env_file)
 
    if not settings.configured:
        settings.configure(
            DEBUG = True,
            ROOT_URLCONF = 'web',
            SWIFT_AUTH_URL = ENV_TOKENS['SWIFT_AUTH_URL'],
            SWIFT_USERNAME = ENV_TOKENS['SWIFT_USERNAME'],
            SWIFT_PASSWORD = ENV_TOKENS['SWIFT_PASSWORD'],
            SWIFT_TENANT_NAME = ENV_TOKENS['SWIFT_TENANT_NAME'],
            SWIFT_CONTAINER_NAME = ENV_TOKENS['SWIFT_CONTAINER_NAME'],
            SWIFT_USE_TEMP_URLS = ENV_TOKENS['SWIFT_USE_TEMP_URLS'],
            SWIFT_TEMP_URL_KEY = ENV_TOKENS['SWIFT_TEMP_URL_KEY'],
            SWIFT_FILE_TO_SHARE = ENV_TOKENS['SWIFT_FILE_TO_SHARE'],
        )
 
    from django.conf.urls import patterns
    urlpatterns = patterns('',
        (r'^$', 'web.index'),
    )
 
    #### Handlers
 
    from django.http import HttpResponse
    from swift.storage import SwiftStorage
 
    def index(request):
        ss = SwiftStorage()
        url = ss.url(settings.SWIFT_FILE_TO_SHARE)
        return HttpResponse(url)
 
    #### Running
 
    if __name__ == '__main__':
        from django.core.management import execute_from_command_line
        execute_from_command_line()
  ``` 

To verify the error:
1. Run `pip install django django-storage-swift`
1. Run `python web.py runserver`
1. Visit http://127.0.0.1:8000.  Note the error: `TypeError: character mapping must return integer, None or unicode`

To verify this change:
1. Build and install the branch from this PR: `python setup.py sdist && pip install dist/dist/django-storage-swift-1.2.15.tar.gz`
1. Run `python web.py runserver`
1. Visit http://127.0.0.1:8000/.  Note that a valid temporary URL is displayed.