### PR TITLE
Do not pass max_length to get_available_name if it's None.

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -324,8 +324,11 @@ class SwiftStorage(Storage):
         available for new content to be written to.
         """
         if not self.auto_overwrite:
-            name = super(SwiftStorage, self).get_available_name(
-                name, max_length)
+            if max_length is None:
+                name = super(SwiftStorage, self).get_available_name(name)
+            else:
+                name = super(SwiftStorage, self).get_available_name(
+                    name, max_length)
 
         if self.name_prefix:
             # Split out the name prefix so we can just return the bit of

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -281,16 +281,12 @@ class BackendTest(SwiftStorageTestCase):
         self.assertEqual(name, object)
 
     def test_get_available_name_max_length_nonexist(self):
-        """Available name for non-existent object"""
+        """Available name with max_length for non-existent object"""
         object = 'images/doesnotexist.png'
         name = self.backend.get_available_name(object, len(object))
         self.assertEqual(name, object)
-
-    def test_get_available_name_max_length_nonexist2(self):
-        """Available name for non-existent object"""
-        object = 'images/doesnotexist.png'
-        name = self.backend.get_available_name(object, 16)
-        self.assertRaises(SuspiciousFileOperation)
+        with self.assertRaises(SuspiciousFileOperation):
+            name = self.backend.get_available_name(object, 16)
 
     def test_get_available_name_exist(self):
         """Available name for existing object"""
@@ -299,7 +295,7 @@ class BackendTest(SwiftStorageTestCase):
         self.assertNotEqual(name, object)
 
     def test_get_available_name_max_length_exist(self):
-        """Available name for existing object"""
+        """Available name with max_length for existing object"""
         object = 'images/test.png'
         name = self.backend.get_available_name(object, 32)
         self.assertNotEqual(name, object)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -280,10 +280,22 @@ class BackendTest(SwiftStorageTestCase):
         name = self.backend.get_available_name(object)
         self.assertEqual(name, object)
 
+    def test_get_available_name_max_length_nonexist(self):
+        """Available name for non-existent object"""
+        object = 'images/doesnotexist.png'
+        name = self.backend.get_available_name(object, 16)
+        self.assertNotEqual(name, object)
+
     def test_get_available_name_exist(self):
         """Available name for existing object"""
         object = 'images/test.png'
         name = self.backend.get_available_name(object)
+        self.assertNotEqual(name, object)
+
+    def test_get_available_name_max_length_exist(self):
+        """Available name for existing object"""
+        object = 'images/test.png'
+        name = self.backend.get_available_name(object, 32)
         self.assertNotEqual(name, object)
 
     def test_get_available_name_prefix(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,7 +2,7 @@
 import hmac
 from copy import deepcopy
 from django.test import TestCase
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, SuspiciousFileOperation
 from django.core.files.base import ContentFile
 from hashlib import sha1
 from mock import patch
@@ -283,8 +283,14 @@ class BackendTest(SwiftStorageTestCase):
     def test_get_available_name_max_length_nonexist(self):
         """Available name for non-existent object"""
         object = 'images/doesnotexist.png'
+        name = self.backend.get_available_name(object, len(object))
+        self.assertEqual(name, object)
+
+    def test_get_available_name_max_length_nonexist2(self):
+        """Available name for non-existent object"""
+        object = 'images/doesnotexist.png'
         name = self.backend.get_available_name(object, 16)
-        self.assertNotEqual(name, object)
+        self.assertRaises(SuspiciousFileOperation)
 
     def test_get_available_name_exist(self):
         """Available name for existing object"""


### PR DESCRIPTION
This is for older versions of django who have get_available_name defined as get_available_name(self, name) and don't support the max_length argument.