### PR TITLE
Properly encode resource names with unicode characters.

### DIFF
--- a/swift/storage.py
+++ b/swift/storage.py
@@ -350,6 +350,10 @@ class SwiftStorage(Storage):
         return self._path(name)
 
     def _path(self, name):
+        try:
+            name = name.encode('utf-8')
+        except UnicodeDecodeError:
+            pass
         url = urlparse.urljoin(self.base_url, urlparse.quote(name))
 
         # Are we building a temporary url?

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -200,6 +200,12 @@ class BackendTest(SwiftStorageTestCase):
         url = self.backend.url(name)
         self.assertEqual(url, base_url(container=self.backend.container_name, path=name))
 
+    def test_url_unicode_name(self):
+        """Get url for a resource with unicode filename"""
+        name = u'images/test终端.png'
+        url = self.backend.url(name)
+        self.assertEqual(url, base_url(container=self.backend.container_name, path=name))
+
     def test_object_size(self):
         """Test getting object size"""
         size = self.backend.size('images/test.png')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from six.moves.urllib import parse as urlparse
 
 BASE_URL = 'https://objects.example.com/v1'
 AUTH_URL = 'https://auth.example.com'
@@ -72,6 +73,10 @@ CONTAINER_CONTENTS = [create_object(path) for path in CONTAINER_FILES]
 
 def base_url(container=None, path=None):
     if container:
+        try:
+            path = urlparse.quote(path.encode('utf-8'))
+        except (UnicodeDecodeError, AttributeError):
+            pass
         return "{}/{}/{}".format(base_url(), container, path or '')
     return "{}/AUTH_{}".format(BASE_URL, TENANT_ID)
 


### PR DESCRIPTION
We observed that filenames with non-ascii characters are properly saved to swift and stored in the database, but when trying to construct the url, the _path method's call to quote() results in KeyErrors if the argument is a string containing non-ascii. This encodes the name with utf-8 so we always pass "bytes" to quote().