### PR TITLE
Require python-swiftclient>=2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     license='MIT',
     packages=['swift'],
     install_requires=[
-        'python-swiftclient>=1.4.0',
+        'python-swiftclient>=2.2.0',
         'python-keystoneclient>=0.2.3',
         'six',
         'python-magic>=0.4.10',


### PR DESCRIPTION
e2618ea introduces use of swiftclient.utils.generate_temp_url which was added in python-swiftclient 2.2.0. (fixes #88 )